### PR TITLE
GH-2840 Add  Newline Delimited JSON-LD format

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
@@ -224,6 +224,17 @@ public class RDFFormat extends FileFormat {
 			SUPPORTS_CONTEXTS, NO_RDF_STAR);
 
 	/**
+	 * The NDJSON-LD is a Newline Delimited JSON-LD format.
+	 * <p>
+	 * The file extension <code>.ndjsonld</code> is recommended for NDJSON-LD documents. The media type is
+	 * <code>application/x-ld+ndjson</code> and the encoding is UTF-8.
+	 * </p>
+	 */
+	public static final RDFFormat NDJSONLD = new RDFFormat("NDJSON-LD", Arrays.asList("application/x-ld+ndjson"),
+			StandardCharsets.UTF_8, Arrays.asList("ndjsonld", "jsonl", "ndjson"), null, SUPPORTS_NAMESPACES,
+			SUPPORTS_CONTEXTS, NO_RDF_STAR);
+
+	/**
 	 * The <a href="http://www.w3.org/TR/rdf-json/" >RDF/JSON</a> file format, an RDF serialization format that supports
 	 * recording of named graphs.
 	 * <p>

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BufferedGroupingRDFHandler.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BufferedGroupingRDFHandler.java
@@ -61,6 +61,10 @@ public class BufferedGroupingRDFHandler extends RDFHandlerWrapper {
 		this.contexts = new HashSet<>();
 	}
 
+	protected Model getBufferedStatements() {
+		return bufferedStatements;
+	}
+
 	@Override
 	public void handleStatement(Statement st) throws RDFHandlerException {
 		synchronized (bufferLock) {
@@ -76,7 +80,7 @@ public class BufferedGroupingRDFHandler extends RDFHandlerWrapper {
 	/*
 	 * not synchronized, assumes calling method has obtained a lock on bufferLock
 	 */
-	private void processBuffer() throws RDFHandlerException {
+	protected void processBuffer() throws RDFHandlerException {
 		// primary grouping per context.
 		for (Resource context : contexts) {
 			Model contextData = bufferedStatements.filter(null, null, null, context);

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -123,8 +123,7 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 				options.setDocumentLoader(loader);
 			}
 			JsonFactory factory = configureNewJsonFactory();
-			JsonParser nextParser = (in != null) ? factory.createParser(in) : factory.createParser(reader);
-			final Object parsedJson = JsonUtils.fromJsonParser(nextParser);
+			final Object parsedJson = getJSONObject(in, reader, factory);
 
 			JsonLdProcessor.toRDF(parsedJson, callback, options);
 		} catch (JsonLdError e) {
@@ -140,6 +139,11 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 		} finally {
 			clear();
 		}
+	}
+
+	protected Object getJSONObject(InputStream in, Reader reader, JsonFactory factory) throws IOException {
+		JsonParser nextParser = (in != null) ? factory.createParser(in) : factory.createParser(reader);
+		return JsonUtils.fromJsonParser(nextParser);
 	}
 
 	/**

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParser.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ndjsonld;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.io.input.BOMInputStream;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.rio.*;
+import org.eclipse.rdf4j.rio.jsonld.JSONLDParser;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.github.jsonldjava.utils.JsonUtils;
+
+/**
+ * Introduce a parser capable of parsing Newline Delimited JSON-LD, where each line is a serialized JSON-LD record. The
+ * format is inspired by Newline Delimited JSON format<a>http://ndjson.org/</a>. Even though each line is a separate
+ * JSON-LD document, the whole document is treated as a single RDF document, having one single BNodes context to
+ * preserve BNodes identifiers.
+ * 
+ * @author Desislava Hristova
+ */
+public class NDJSONLDParser extends JSONLDParser implements RDFParser {
+
+	/**
+	 * Default constructor
+	 */
+	public NDJSONLDParser() {
+		super();
+	}
+
+	/**
+	 * Creates a RDF4J NDJSONLD Parser using the given {@link ValueFactory} to create new {@link Value}s.
+	 *
+	 * @param valueFactory The ValueFactory to use
+	 */
+	public NDJSONLDParser(final ValueFactory valueFactory) {
+		super(valueFactory);
+	}
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.NDJSONLD;
+	}
+
+	@Override
+	protected Object getJSONObject(InputStream in, Reader reader, JsonFactory factory) throws IOException {
+		List<Object> arrayOfJSONLD = new LinkedList<>();
+		try (BufferedReader bufferedReader = new BufferedReader(reader)) {
+			String line;
+			while ((line = bufferedReader.readLine()) != null) {
+				if (!line.isEmpty()) {
+					JsonParser nextParser = factory.createParser(new ByteArrayInputStream(line.getBytes()));
+					Object singleJSONLD = JsonUtils.fromJsonParser(nextParser);
+					if (singleJSONLD instanceof List) {
+						arrayOfJSONLD.addAll((List) singleJSONLD);
+					} else {
+						arrayOfJSONLD.add(singleJSONLD);
+					}
+				}
+			}
+			return arrayOfJSONLD;
+		}
+	}
+
+	@Override
+	public void parse(InputStream in, String baseURI) throws RDFParseException, RDFHandlerException, IOException {
+		if (in == null) {
+			throw new IllegalArgumentException("Input stream must not be 'null'");
+		}
+
+		parse(new InputStreamReader(new BOMInputStream(in, false), StandardCharsets.UTF_8), baseURI);
+	}
+}

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserFactory.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserFactory.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ndjsonld;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+
+/**
+ * An {@link RDFParserFactory} that creates instances of {@link NDJSONLDParser}.
+ */
+public class NDJSONLDParserFactory implements RDFParserFactory {
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.NDJSONLD;
+	}
+
+	@Override
+	public RDFParser getParser() {
+		return new NDJSONLDParser();
+	}
+
+}

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriter.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ndjsonld;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.rio.*;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.BufferedGroupingRDFHandler;
+import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
+import org.eclipse.rdf4j.rio.jsonld.JSONLDWriter;
+
+public class NDJSONLDWriter extends AbstractRDFWriter implements RDFWriter {
+
+	private final BufferedGroupingRDFHandler bufferedGroupingRDFHandler;
+
+	private final LinkedHashMap<String, String> namespacesBuffer;
+
+	/**
+	 * Creates a new NDJSONLDWriter that will write to the supplied OutputStream.
+	 *
+	 * @param outputStream The OutputStream to write the NDJSONLD document to.
+	 */
+	public NDJSONLDWriter(OutputStream outputStream) {
+		this(outputStream, null);
+	}
+
+	public NDJSONLDWriter(Writer writer) {
+		this(writer, null);
+	}
+
+	public NDJSONLDWriter(OutputStream out, String baseURI) {
+		this(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8)), baseURI);
+	}
+
+	public NDJSONLDWriter(Writer writer, String baseURI) {
+		namespacesBuffer = new LinkedHashMap<>();
+		bufferedGroupingRDFHandler = new BufferedGroupingRDFHandler() {
+
+			@Override
+			protected void processBuffer() throws RDFHandlerException {
+				for (Resource context : getBufferedStatements().contexts()) {
+					for (Resource subject : getBufferedStatements().subjects()) {
+						JSONLDWriter jsonldWriter = getJsonldWriter(writer, baseURI);
+						Iterable<Statement> statements = getBufferedStatements().getStatements(subject, null, null,
+								context);
+						jsonldWriter.startRDF();
+						for (String key : namespacesBuffer.keySet()) {
+							jsonldWriter.handleNamespace(key, namespacesBuffer.get(key));
+						}
+						for (Statement st : statements) {
+							jsonldWriter.handleStatement(st);
+						}
+						jsonldWriter.endRDF();
+						try {
+							jsonldWriter.getWriter().write(System.lineSeparator());
+						} catch (IOException e) {
+							throw new RDFHandlerException(e);
+						}
+					}
+				}
+
+				getBufferedStatements().clear();
+			}
+		};
+	}
+
+	private JSONLDWriter getJsonldWriter(Writer writer, String baseURI) {
+		JSONLDWriter jsonldWriter = new JSONLDWriter(writer, baseURI);
+		jsonldWriter.setWriterConfig(getWriterConfig());
+		jsonldWriter.getWriterConfig().set(BasicWriterSettings.PRETTY_PRINT, false);
+		return jsonldWriter;
+	}
+
+	@Override
+	public void handleStatement(Statement st) throws RDFHandlerException {
+		bufferedGroupingRDFHandler.handleStatement(st);
+	}
+
+	@Override
+	public void startRDF() throws RDFHandlerException {
+		bufferedGroupingRDFHandler.startRDF();
+	}
+
+	@Override
+	public void endRDF() throws RDFHandlerException {
+		bufferedGroupingRDFHandler.endRDF();
+	}
+
+	@Override
+	public void handleNamespace(String prefix, String uri) throws RDFHandlerException {
+		namespacesBuffer.put(prefix, uri);
+	}
+
+	@Override
+	public void handleComment(String comment) throws RDFHandlerException {
+		// comments are not handled by JSON-LD Writer, so do nothing
+	}
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.NDJSONLD;
+	}
+
+	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		Collection<RioSetting<?>> result = new HashSet<>(Arrays.asList(
+				BasicWriterSettings.BASE_DIRECTIVE,
+				JSONLDSettings.COMPACT_ARRAYS,
+				JSONLDSettings.HIERARCHICAL_VIEW,
+				JSONLDSettings.JSONLD_MODE,
+				JSONLDSettings.PRODUCE_GENERALIZED_RDF,
+				JSONLDSettings.USE_RDF_TYPE,
+				JSONLDSettings.USE_NATIVE_TYPES
+		));
+		return result;
+	}
+}

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterFactory.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterFactory.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ndjsonld;
+
+import java.io.OutputStream;
+import java.io.Writer;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+
+public class NDJSONLDWriterFactory implements RDFWriterFactory {
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.NDJSONLD;
+	}
+
+	@Override
+	public RDFWriter getWriter(OutputStream out) {
+		return new NDJSONLDWriter(out);
+	}
+
+	@Override
+	public RDFWriter getWriter(OutputStream out, String baseURI) {
+		return new NDJSONLDWriter(out, baseURI);
+	}
+
+	@Override
+	public RDFWriter getWriter(Writer writer) {
+		return new NDJSONLDWriter(writer);
+	}
+
+	@Override
+	public RDFWriter getWriter(Writer writer, String baseURI) {
+		return new NDJSONLDWriter(writer, baseURI);
+	}
+}

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/package-info.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/package-info.java
@@ -1,0 +1,1 @@
+package org.eclipse.rdf4j.rio.ndjsonld;

--- a/core/rio/jsonld/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFParserFactory
+++ b/core/rio/jsonld/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFParserFactory
@@ -1,1 +1,3 @@
 org.eclipse.rdf4j.rio.jsonld.JSONLDParserFactory
+org.eclipse.rdf4j.rio.ndjsonld.NDJSONLDParserFactory
+

--- a/core/rio/jsonld/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
+++ b/core/rio/jsonld/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
@@ -1,1 +1,2 @@
 org.eclipse.rdf4j.rio.jsonld.JSONLDWriterFactory
+org.eclipse.rdf4j.rio.ndjsonld.NDJSONLDWriterFactory

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserHandlerTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserHandlerTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ndjsonld;
+
+import java.io.OutputStream;
+
+import org.eclipse.rdf4j.rio.AbstractParserHandlingTest;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+
+public class NDJSONLDParserHandlerTest extends AbstractParserHandlingTest {
+
+	@Override
+	protected RDFParser getParser() {
+		return new NDJSONLDParser();
+	}
+
+	@Override
+	protected RDFWriter createWriter(OutputStream output) {
+		return new NDJSONLDWriter(output);
+	}
+}

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ndjsonld;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collection;
+
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.Test;
+
+public class NDJSONLDParserTest {
+
+	private ValueFactory vf = SimpleValueFactory.getInstance();
+
+	@Test
+	public void testNDJSONLDWriter() throws IOException {
+		NDJSONLDParser ndjsonldParser = new NDJSONLDParser();
+		ndjsonldParser.getParserConfig().set(BasicWriterSettings.BASE_DIRECTIVE, true);
+		StatementCollector statementCollector = new StatementCollector();
+		ndjsonldParser.setRDFHandler(statementCollector);
+		ndjsonldParser.parse(new FileInputStream("src/test/resources/testcases/ndjsonld/mates.ndjsonld"));
+		Collection<Statement> statements = statementCollector.getStatements();
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate1"), RDF.TYPE,
+				vf.createIRI("http://schema.org/Person"))));
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate2"), RDF.TYPE,
+				vf.createIRI("http://schema.org/Person"))));
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate1"),
+				vf.createIRI("http://schema.org/givenName"), vf.createLiteral("Mate1"))));
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate2"),
+				vf.createIRI("http://schema.org/givenName"), vf.createLiteral("Mate2"))));
+	}
+
+	@Test
+	public void testNDJSONLDParser() throws IOException {
+		NDJSONLDParser ndjsonldParser = new NDJSONLDParser();
+		ndjsonldParser.getParserConfig().set(BasicWriterSettings.BASE_DIRECTIVE, true);
+		StatementCollector statementCollector = new StatementCollector();
+		ndjsonldParser.setRDFHandler(statementCollector);
+		ndjsonldParser.parse(new FileInputStream("src/test/resources/testcases/ndjsonld/mates.ndjsonld"));
+		Collection<Statement> statements = statementCollector.getStatements();
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate1"), RDF.TYPE,
+				vf.createIRI("http://schema.org/Person"))));
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate2"), RDF.TYPE,
+				vf.createIRI("http://schema.org/Person"))));
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate1"),
+				vf.createIRI("http://schema.org/givenName"), vf.createLiteral("Mate1"))));
+		assertTrue(statements.contains(vf.createStatement(vf.createIRI("http://ndjsonld.com/Mate2"),
+				vf.createIRI("http://schema.org/givenName"), vf.createLiteral("Mate2"))));
+	}
+
+}

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ndjsonld;
+
+import java.io.IOException;
+
+import org.eclipse.rdf4j.rio.*;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
+import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class NDJSONLDWriterTest extends RDFWriterTest {
+
+	public NDJSONLDWriterTest() {
+		super(new NDJSONLDWriterFactory(), new NDJSONLDParserFactory());
+	}
+
+	@Test
+	@Override
+	@Ignore("TODO: See case for JSONLDWriterTest")
+	public void testIllegalPrefix() throws RDFHandlerException, RDFParseException, IOException {
+	}
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		super.setupWriterConfig(config);
+		config.set(JSONLDSettings.JSONLD_MODE, JSONLDMode.COMPACT);
+	}
+
+	@Override
+	protected void setupParserConfig(ParserConfig config) {
+		super.setupParserConfig(config);
+		config.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
+		config.set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {
+				BasicWriterSettings.BASE_DIRECTIVE,
+				JSONLDSettings.COMPACT_ARRAYS,
+				JSONLDSettings.HIERARCHICAL_VIEW,
+				JSONLDSettings.JSONLD_MODE,
+				JSONLDSettings.PRODUCE_GENERALIZED_RDF,
+				JSONLDSettings.USE_RDF_TYPE,
+				JSONLDSettings.USE_NATIVE_TYPES
+		};
+	}
+}

--- a/core/rio/jsonld/src/test/resources/testcases/ndjsonld/mates.ndjsonld
+++ b/core/rio/jsonld/src/test/resources/testcases/ndjsonld/mates.ndjsonld
@@ -1,0 +1,3 @@
+{  "@id" : "http://ndjsonld.com/Mate1",  "@type":["http://schema.org/Person"], "http://schema.org/givenName":[{"@value":"Mate1"}]}
+
+{  "@id" : "http://ndjsonld.com/Mate2",  "@type":["http://schema.org/Person"], "http://schema.org/givenName":[{"@value":"Mate2"}]}


### PR DESCRIPTION
Introduce a NDJSONLD format which is a combination of http://ndjson.org/ and JSON-LD, i.e multiline JSON LD format. 

- Introduce a NDJSONLDParser that delegates parsing to a JSONLDParser for each line of the input. For a single parse call one JSONLDParser is reused. 
-  Introduce a NDJSONLDWriter that combines statements by uibject extending the BufferedGroupingRDFHandler and for each group, writes a single JSON-LD line using the JSONLDWriter, resulting in a ndjsonld RDF result. Supports JSON-LD Writer settings by passing them to the delegate Writer.
